### PR TITLE
fix: remove devtools dependency

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -27,8 +27,8 @@ checkPackage <- function(pkgName, repoDir, subdir = NULL) {
   cat("Check")
   rcmdcheck::rcmdcheck(
     pkgDir, 
-    error_on = 'error', 
-    args = ("--no-build-vignettes", "--no-examples", "--no-manual", "--no-tests")
+    error_on = "error", 
+    args = c("--no-build-vignettes", "--no-examples", "--no-manual", "--no-tests")
   )
   
   depsYaml <- file.path(repoDir, "rplatform", "dependencies.yaml")


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: 

## Why was it changed?

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
