### PR TITLE
feat: ignore note(s) for >50 lines per function in biocCheck

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 0.99.14
-Date: 2023-04-27
+Version: 0.99.15
+Date: 2023-05-02
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## [0.99.15] - 2023-05-02
+- ignore note for 50 lines per function in biocCheck
+
 ## [0.99.14] - 2023-04-27
 - removed CRAN check from biocCheck
 

--- a/inst/config/note.json
+++ b/inst/config/note.json
@@ -28,6 +28,11 @@
     {
       "length": 1,
       "index_to_check": 1,
+      "text_to_check": "The longest 5 functions are"
+    },
+    {
+      "length": 1,
+      "index_to_check": 1,
       "text_to_check": "Update R version dependency from 4.2 to 4.3.0."
     }
   ]


### PR DESCRIPTION
# Goal
- ignore notes for >50 lines per function in BiocCheck
- see more details at https://gred.slack.com/archives/C028XVA7ZFF/p1683017403517449.

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
