### PR TITLE
[GDR-1975] data.frame-related functions & update package versioning rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 0.99.16
-Date: 2023-05-04
+Version: 0.99.17
+Date: 2023-05-10
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),
@@ -22,7 +22,7 @@ Imports:
     BiocManager,
     desc,
     git2r,
-    lintr,
+    lintr (>= 3.0.0),
     rcmdcheck,
     remotes,
     yaml,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## [0.99.17] - 2023-05-10
+- add check for data.frame-related functions
+- update package versioning rules
+
 ## [0.99.16] - 2023-05-04
 - ignore note for exported functions without examples
 - handle properly BiocCheck notes with mulitple lines (notes to be ignored)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -17,7 +17,7 @@
 #'   dep_path = 
 #'         system.file(package = "gDRstyle", "testdata", "dependencies.yaml"),
 #'   desc_path = system.file(package = "gDRstyle", "DESCRIPTION"),
-#'   skip_pkgs = "testthat"
+#'   skip_pkgs = c("testthat", "lintr")
 #' )
 #'
 #' @return \code{NULL} invisibly.

--- a/R/linter_custom.R
+++ b/R/linter_custom.R
@@ -8,12 +8,7 @@
 #' @author Kamil Foltynski <kamil.foltynski@contractors.roche.com>
 #' 
 #' @examples
-#'  linter_helper_function <- if (packageVersion("lintr") >= "3.0.0") {
-#'    lintr::linters_with_defaults
-#'  } else {
-#'    lintr::with_defaults
-#'  }
-#' linters_config <- linter_helper_function(
+#' linters_config <- lintr::linters_with_defaults(
 #'   line_length_linter = lintr::line_length_linter(120),
 #'   roxygen_tag_linter = roxygen_tag_linter()
 #' )

--- a/R/linters_config.R
+++ b/R/linters_config.R
@@ -4,7 +4,9 @@ gDR_undesirable_functions <-
     "library" = NULL,
     # we prefer not to use these functions because we use data.table as the primary data format
     "assert_data_frame" = "please use 'checkmate::assert_data_table' instead (data.table is primary data format)",
-    "rbind.fill" = "please use 'data.table::rbindlist' instead (data.table is primary data format)"
+    "rbind.fill" = "please use 'data.table::rbindlist' instead (data.table is primary data format)",
+    "read.csv" = "please use 'data.table::fread' instead (data.table is primary data format)",
+    "as.data.frame" = "data.table is primary data format (probably you should use `merge.data.frame`)"
   )
 
 #' @noRd

--- a/R/linters_config.R
+++ b/R/linters_config.R
@@ -1,24 +1,22 @@
+gDR_undesirable_functions <-
+  lintr::modify_defaults(
+    defaults = lintr::default_undesirable_functions,
+    "library" = NULL,
+    # we prefer not to use these functions because we use data.table as the primary data format
+    "assert_data_frame",
+    "rbind.fill"
+  )
+
 #' @noRd
-linters_config <-  if (packageVersion("lintr") >= "3.0.0") {
-    lintr::linters_with_defaults(
-      cyclocomp_linter = NULL,
-      line_length_linter = lintr::line_length_linter(120),
-      object_name_linter = NULL,
-      seq_linter = NULL,
-      trailing_blank_lines_linter = NULL,
-      trailing_whitespace_linter = NULL,
-      object_usage_linter = NULL,
-      object_length_linter = NULL
-    )
-  } else {
-    lintr::with_defaults(
-      cyclocomp_linter = NULL,
-      line_length_linter = lintr::line_length_linter(120),
-      object_name_linter = NULL,
-      seq_linter = NULL,
-      trailing_blank_lines_linter = NULL,
-      trailing_whitespace_linter = NULL,
-      object_usage_linter = NULL,
-      object_length_linter = NULL
-    )
-  }
+linters_config <- 
+  lintr::linters_with_defaults(
+    cyclocomp_linter = NULL,
+    line_length_linter = lintr::line_length_linter(120),
+    object_name_linter = NULL,
+    seq_linter = NULL,
+    trailing_blank_lines_linter = NULL,
+    trailing_whitespace_linter = NULL,
+    object_usage_linter = NULL,
+    object_length_linter = NULL,
+    undesirable_function_linter = lintr::undesirable_function_linter(fun = gDR_undesirable_functions)
+  )

--- a/R/linters_config.R
+++ b/R/linters_config.R
@@ -3,8 +3,8 @@ gDR_undesirable_functions <-
     defaults = lintr::default_undesirable_functions,
     "library" = NULL,
     # we prefer not to use these functions because we use data.table as the primary data format
-    "assert_data_frame",
-    "rbind.fill"
+    "assert_data_frame" = "please use 'checkmate::assert_data_table' instead (data.table is primary data format)",
+    "rbind.fill" = "please use 'data.table::rbindlist' instead (data.table is primary data format)"
   )
 
 #' @noRd

--- a/R/linters_config.R
+++ b/R/linters_config.R
@@ -2,6 +2,11 @@ gDR_undesirable_functions <-
   lintr::modify_defaults(
     defaults = lintr::default_undesirable_functions,
     "library" = NULL,
+    # we use also these functions in our code but it would be cleaned eventually
+    "mapply" = NULL,
+    "options" = NULL,
+    "source" = NULL,
+    "Sys.setenv" = NULL,
     # we prefer not to use these functions because we use data.table as the primary data format
     "assert_data_frame" = "please use 'checkmate::assert_data_table' instead (data.table is primary data format)",
     "rbind.fill" = "please use 'data.table::rbindlist' instead (data.table is primary data format)",

--- a/R/linters_config.R
+++ b/R/linters_config.R
@@ -8,10 +8,10 @@ gDR_undesirable_functions <-
     "source" = NULL,
     "Sys.setenv" = NULL,
     # we prefer not to use these functions because we use data.table as the primary data format
-    "assert_data_frame" = "please use 'checkmate::assert_data_table' instead (data.table is primary data format)",
-    "rbind.fill" = "please use 'data.table::rbindlist' instead (data.table is primary data format)",
-    "read.csv" = "please use 'data.table::fread' instead (data.table is primary data format)",
-    "as.data.frame" = "data.table is primary data format (probably you should use `merge.data.frame`)"
+    "assert_data_frame" = "please use `checkmate::assert_data_table` instead (data.table is primary data format)",
+    "rbind.fill" = "please use `data.table::rbindlist` instead (data.table is primary data format)",
+    "read.csv" = "pleae use `data.table::fread` instead (data.table is primary data format)",
+    "as.data.frame" = "please use `data.table::as.data.table` instead (data.table is primary data format)"
   )
 
 #' @noRd

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -29,6 +29,7 @@ A style guide for the gdrplatform organization.
     * Functions definition should start on the same line as function name
     * Every parameter should be in separate line
     * Prepare separate functions for complicated defaults (of function parameters)
+
 ```{r}
  # Good
 fun <- function(param1,
@@ -52,7 +53,8 @@ fun <- function(param1, param2, param_with_dir_for_st_important = file.path(syst
   * Do not use `apply` on data.frame(s) (`mapply` is good for row-wise operations) 
   * Function returns
     * Use implicit returns over explicit
-```
+
+```{r}
   # Good.
   foo <- function() {
     # Do stuff.
@@ -64,9 +66,9 @@ fun <- function(param1, param2, param_with_dir_for_st_important = file.path(syst
     return(x)
   }
 ```
+
 6. Use of curly braces
   * `if` and `else` statements should be surrounded by curly braces on the same line
-
 ```{r}
 if (TRUE) {
   NULL
@@ -103,7 +105,7 @@ what_is_going_on <- if (is_check()) {
   * If anything is hardcoded (i.e. numbers or strings), consider refactoring by introducing additional function arguments or inserting logic over numbers.
     * `df[, fxn_that_returns_idx(x):length(x)] <- NA` over `df[, 2:length(x)] <- NA`
   * Reassign repeated logic to a variable computed only once.
-```
+```{r}
 # Good.
 idx <- foo()
 if (length(idx) == 1) {
@@ -125,7 +127,7 @@ if (length(foo()) == 1) {
 ## General package code
 1. Create file _{pkgname}-package.R_ with `usethis::use_package_doc()`
 2. Update _{pkgname}-package.R_ - it should have such lines:
-```
+```{r}
 #' @note To learn more about functions start with `help(package = "{pkgname}")` 
 #' @keywords internal
 #' @return package help page
@@ -141,10 +143,15 @@ if the requirements for Bioconductor are also met)
 ## Git best practices
 1. Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
   * Commit messages should look like `<type>: <description>` where `type` can be one of:
-    * `fix`: for bugfixes; this should be accompanied by a bumped `PATCH` version
-    * `feat`: for new features; this should be accompanied by a bumped `MINOR` version
-    * `docs`: for documentation changes; no version changes
-    * `style`: for formatting changes that do not affect the meaning of the code; no version changes
-    * `test`: for adding missing tests or correcting existing tests; no version changes
+    * `fix`: for bugfixes; 
+    * `feat`: for new features;
+    * `docs`: for documentation changes;
+    * `style`: for formatting changes that do not affect the meaning of the code;
+    * `test`: for adding missing tests or correcting existing tests;
     * `refactor`: for code changes that neither fixes a bug nor adds a feature
     * `ci`: for changes to CI configuration
+2. Any change in code should be accompanied by a bumped version.
+  * new features - `PATCH` version;
+  * bugfixes and other changes - `MINOR` version.
+*Exceptions*: All public packages - as to-be-released on Bioconductor have version 0.99.x.  
+Any changes in code should be accompanied by a bumped `MINOR` version regardless of the nature of the changes.

--- a/inst/testdata/dummy_functions_df.R
+++ b/inst/testdata/dummy_functions_df.R
@@ -1,0 +1,20 @@
+#' dummy_fun1
+#'
+#' @return
+#' @export
+#'
+dummy_fun5 <- function(df) {
+  checkmate::assert_data_frame(df)
+  NROW(df)
+}
+
+#' dummy_fun2
+#'
+#' Dummy documented function
+#'
+#' @export
+#'
+#' @author Jane Doe
+dummy_fun2 <- function() {
+  plyr::rbind.fill(mtcars[c("mpg", "wt")], mtcars[c("wt", "cyl")])
+}

--- a/man/checkDependencies.Rd
+++ b/man/checkDependencies.Rd
@@ -40,7 +40,7 @@ checkDependencies(
   dep_path = 
         system.file(package = "gDRstyle", "testdata", "dependencies.yaml"),
   desc_path = system.file(package = "gDRstyle", "DESCRIPTION"),
-  skip_pkgs = "testthat"
+  skip_pkgs = c("testthat", "lintr")
 )
 
 }

--- a/man/roxygen_tag_linter.Rd
+++ b/man/roxygen_tag_linter.Rd
@@ -17,12 +17,7 @@ Check that function has documented specific tag in Roxygen
 skeleton (default \code{@author}).
 }
 \examples{
- linter_helper_function <- if (packageVersion("lintr") >= "3.0.0") {
-   lintr::linters_with_defaults
- } else {
-   lintr::with_defaults
- }
-linters_config <- linter_helper_function(
+linters_config <- lintr::linters_with_defaults(
   line_length_linter = lintr::line_length_linter(120),
   roxygen_tag_linter = roxygen_tag_linter()
 )

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -1,8 +1,5 @@
-library(testthat)
-library(gDRstyle)
-
-test_that("checkDependencies works as expected", {
-  expect_error(checkDependencies(
+testthat::test_that("checkDependencies works as expected", {
+  testthat::expect_error(checkDependencies(
     dep_path = system.file(
       package = "gDRstyle", "testdata", "rplatform", "dependencies.yaml"
     ),
@@ -16,7 +13,7 @@ test_that("checkDependencies works as expected", {
   )
 })
 
-test_that("skiping in checkDependencies works as expected", {
+testthat::test_that("skiping in checkDependencies works as expected", {
   checkDependencies(
     dep_path = system.file(
       package = "gDRstyle",
@@ -30,14 +27,14 @@ test_that("skiping in checkDependencies works as expected", {
   )
 })
 
-test_that("compare_versions works as expected", {
+testthat::test_that("compare_versions works as expected", {
   rp <- list("A" = ">= 1.0.0", B = ">= 1.2.1")
   desc <- list("A" = ">= 1.0.0", B = ">=1.2.2")
-  expect_equal(gDRstyle:::compare_versions(rp, rp), NULL)
-  expect_equal(gDRstyle:::compare_versions(rp, desc), "B")
-  expect_error(gDRstyle:::compare_versions(rp, desc[1]))
+  testthat::expect_equal(gDRstyle:::compare_versions(rp, rp), NULL)
+  testthat::expect_equal(gDRstyle:::compare_versions(rp, desc), "B")
+  testthat::expect_error(gDRstyle:::compare_versions(rp, desc[1]))
 
   rp2 <- list("A" = ">= 1.0.0", C = ">= 1.2.1")
   desc2 <- list("A" = ">= 1.0.0", C = "*")
-  expect_equal(gDRstyle:::compare_versions(rp2, desc2), "C")
+  testthat::expect_equal(gDRstyle:::compare_versions(rp2, desc2), "C")
 })

--- a/tests/testthat/test-linter.R
+++ b/tests/testthat/test-linter.R
@@ -1,18 +1,18 @@
-test_that("linting functions work as expected", {
+testthat::test_that("linting functions work as expected", {
   # Bad.
   pkg_path <- system.file(package = "gDRstyle", "tst_pkgs", "dummy_pkg_errors")
-  expect_error(withr::with_dir(pkg_path, lintPkgDirs(".")), regex = "*test.R")
+  testthat::expect_error(withr::with_dir(pkg_path, lintPkgDirs(".")), regex = "*test.R")
 
   # Good.
   pkg_path <- system.file(package = "gDRstyle", "tst_pkgs", "dummy_pkg")
-  expect_error(withr::with_dir(pkg_path, lintPkgDirs(".")), NA)
+  testthat:: expect_error(withr::with_dir(pkg_path, lintPkgDirs(".")), NA)
 })
 
-test_that("avoid_new_lines works as expected", {
+testthat::test_that("avoid_new_lines works as expected", {
   text <- "Lorem ipsum dolor sit amet, %s adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
     veniam."
 
-  expect_true(grepl("\n", sprintf(text, "consectetur")))
-  expect_false(grepl("\n", sprintf(avoid_new_lines(text), "consectetur")))
+  testthat::expect_true(grepl("\n", sprintf(text, "consectetur")))
+  testthat::expect_false(grepl("\n", sprintf(avoid_new_lines(text), "consectetur")))
 })

--- a/tests/testthat/test-linters_config.R
+++ b/tests/testthat/test-linters_config.R
@@ -1,0 +1,10 @@
+testthat::test_that("custom `gDR_undesirable_functions` works as expected", {
+  linters_config <- lintr::linters_with_defaults(
+    undesirable_function_linter = lintr::undesirable_function_linter(fun = gDR_undesirable_functions)
+  )
+  file <- system.file("testdata", "dummy_functions_df.R", package = "gDRstyle")
+  lint_results <- lintr::lint(file, linters = linters_config)
+  lint_results_df <- data.frame(lint_results, stringsAsFactors = FALSE)
+  testthat::expect_equal(lint_results_df$line_number, c(7L, 19L))
+  testthat::expect_true(all(grepl("\"assert_data_frame\"|\"rbind.fill\"", lint_results_df$message)))
+})

--- a/tests/testthat/test-roxygen-tag-linter.R
+++ b/tests/testthat/test-roxygen-tag-linter.R
@@ -1,10 +1,5 @@
-test_that("custom linter `roxygen_tag_linter` works as expected", {
-  linter_helper_function <- if (packageVersion("lintr") >= "3.0.0") {
-    lintr::linters_with_defaults
-  } else {
-    lintr::with_defaults
-  }
-  linters_config <- linter_helper_function(
+testthat::test_that("custom linter `roxygen_tag_linter` works as expected", {
+  linters_config <- lintr::linters_with_defaults(
     roxygen_tag_linter = roxygen_tag_linter()
   )
   file <- system.file("testdata", "dummy_functions.R", package = "gDRstyle")


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-1975

## Why was it changed?
- add new rules to lintr (data.frame-related functions)
- update package versioning rules acc to technical meeting

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
