### PR TITLE
Gdr 2437

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 1.1.4
-Date: 2024-02-26
+Version: 1.1.5
+Date: 2024-03-04
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ biocViews: Software, Infrastructure
 VignetteBuilder: knitr
 ByteCompile: TRUE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRstyle 1.1.5 - 2024-03-04
+* remove `:::` from notes exceptions
+
 ## gDRstyle 1.1.4 - 2024-02-26
 * improve pkgdown site
   * improved references

--- a/R/build_tools.R
+++ b/R/build_tools.R
@@ -57,7 +57,9 @@ verify_version <- function(name,
   ## '>=1.2.3' => '>= 1.2.3'
   required_version <-
     gsub("^([><=]+)([0-9.]+)$", "\\1 \\2", required_version, perl = TRUE)
+  #nolint start
   if (!remotes:::version_satisfies_criteria(pkg_version, required_version)) {
+  #nolint stop
     stop(sprintf(
       "Invalid version of %s. Installed: %s, required %s.",
       name,
@@ -287,18 +289,3 @@ install_gitlab <- function(name,
   verify_version(name, pkg$ver)
 }
 # nocov end
-
-#' @source package `remotes`
-#' @keywords internal
-  version_satisfies_criteria <- function(to_check, criteria) {
-  to_check <- package_version(to_check)
-  result <- apply(version_criteria(criteria), 1, function(r) {
-    if (is.na(r["compare"])) {
-      TRUE
-    }
-    else {
-      get(r["compare"], mode = "function")(to_check, r["version"])
-    }
-  })
-  all(result)
-}

--- a/R/build_tools.R
+++ b/R/build_tools.R
@@ -59,7 +59,7 @@ verify_version <- function(name,
     gsub("^([><=]+)([0-9.]+)$", "\\1 \\2", required_version, perl = TRUE)
   # TODO: get rid of usage `:::`
   #nolint start
-  if (!remotes:::version_satisfies_criteria(pkg_version, required_version)) {
+  if (!remotes::version_satisfies_criteria(pkg_version, required_version)) {
   #nolint stop
     stop(sprintf(
       "Invalid version of %s. Installed: %s, required %s.",

--- a/R/build_tools.R
+++ b/R/build_tools.R
@@ -57,6 +57,7 @@ verify_version <- function(name,
   ## '>=1.2.3' => '>= 1.2.3'
   required_version <-
     gsub("^([><=]+)([0-9.]+)$", "\\1 \\2", required_version, perl = TRUE)
+  # TODO: get rid of usage `:::`
   #nolint start
   if (!remotes:::version_satisfies_criteria(pkg_version, required_version)) {
   #nolint stop

--- a/R/build_tools.R
+++ b/R/build_tools.R
@@ -287,3 +287,18 @@ install_gitlab <- function(name,
   verify_version(name, pkg$ver)
 }
 # nocov end
+
+#' @source package `remotes`
+#' @keywords internal
+  version_satisfies_criteria <- function(to_check, criteria) {
+  to_check <- package_version(to_check)
+  result <- apply(version_criteria(criteria), 1, function(r) {
+    if (is.na(r["compare"])) {
+      TRUE
+    }
+    else {
+      get(r["compare"], mode = "function")(to_check, r["version"])
+    }
+  })
+  all(result)
+}

--- a/man/gDRstyle-package.Rd
+++ b/man/gDRstyle-package.Rd
@@ -24,19 +24,20 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Arkadiusz Gladki \email{gladki.arkadiusz@gmail.com} [contributor]
+\strong{Maintainer}: Arkadiusz Gladki \email{gladki.arkadiusz@gmail.com} (\href{https://orcid.org/0000-0002-7059-6378}{ORCID})
 
 Authors:
 \itemize{
   \item Allison Vuong
   \item Dariusz Scigocki
   \item Marcin Kamianowski
+  \item Janina Smola
+  \item Bartosz Czech (\href{https://orcid.org/0000-0002-9908-3007}{ORCID})
 }
 
 Other contributors:
 \itemize{
   \item Aleksander Chlebowski [contributor]
-  \item Bartosz Czech [contributor]
 }
 
 }

--- a/rplatform/valid_notes2.R
+++ b/rplatform/valid_notes2.R
@@ -1,10 +1,5 @@
 global_valid_notes_l <- list(
   list(
-    length = 3,
-    index_to_check = 2,
-    text_to_check = "Unexported object imported by a ':::' call: ‘remotes:::version_satisfies_criteria’"
-  ),
-  list(
     length = 5,
     index_to_check = 2,
     text_to_check = "installed size is"

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -30,11 +30,11 @@ testthat::test_that("skiping in checkDependencies works as expected", {
 testthat::test_that("compare_versions works as expected", {
   rp <- list("A" = ">= 1.0.0", B = ">= 1.2.1")
   desc <- list("A" = ">= 1.0.0", B = ">=1.2.2")
-  testthat::expect_equal(gDRstyle:::compare_versions(rp, rp), NULL)
-  testthat::expect_equal(gDRstyle:::compare_versions(rp, desc), "B")
-  testthat::expect_error(gDRstyle:::compare_versions(rp, desc[1]))
+  testthat::expect_equal(compare_versions(rp, rp), NULL)
+  testthat::expect_equal(compare_versions(rp, desc), "B")
+  testthat::expect_error(compare_versions(rp, desc[1]))
 
   rp2 <- list("A" = ">= 1.0.0", C = ">= 1.2.1")
   desc2 <- list("A" = ">= 1.0.0", C = "*")
-  testthat::expect_equal(gDRstyle:::compare_versions(rp2, desc2), "C")
+  testthat::expect_equal(compare_versions(rp2, desc2), "C")
 })


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-2437

## Why was it changed?
To not to support `:::` exceptions in check notes

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
