### PR TITLE
feat: add support for running `R CMD CHECK` with `--as-cran`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /doc/
 /docs/
 /Meta/
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Depends:
 Imports:
     BiocCheck,
     BiocManager,
+    checkmate,
     desc,
     git2r,
     lintr (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 1.1.7
-Date: 2024-03-20
+Version: 1.1.8
+Date: 2024-03-25
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRstyle 1.1.8 - 2024-03-25
+* add as_cran flag
+
 ## gDRstyle 1.1.7 - 2024-03-20
 * replace `remotes:::version_satisfies_criteria` function
 

--- a/R/check.R
+++ b/R/check.R
@@ -119,7 +119,8 @@ rcmd_check_with_notes <- function(pkgDir,
                                   run_examples,
                                   bioc_check,
                                   build_vignettes, 
-                                  check_vignettes) {
+                                  check_vignettes,
+                                  as_cran) {
   # rcmdcheck gets warning instead of note
   error_on <- `if`(fail_on == "note", "warning", fail_on)
   check_args <- c("--no-manual", "--no-tests")
@@ -131,6 +132,10 @@ rcmd_check_with_notes <- function(pkgDir,
   
   if (!check_vignettes) {
     check_args <- c(check_args, "--ignore-vignettes")
+  }
+
+  if (as_cran) {
+    check_args <- c(check_args, "--as-cran")
   }
   
   if (!build_vignettes) {
@@ -183,6 +188,7 @@ rcmd_check_with_notes <- function(pkgDir,
 #' @param skip_tests skip tests
 #' @param build_vignettes build vignettes
 #' @param check_vignettes check vignettes
+#' @param as_cran run with as_cran flag
 #'
 #' @examples
 #' checkPackage(
@@ -203,8 +209,10 @@ checkPackage <- function(pkgName,
                          skip_lint = FALSE,
                          skip_tests = FALSE,
                          build_vignettes = TRUE,
-                         check_vignettes = TRUE) {
+                         check_vignettes = TRUE,
+                         as_cran = FALSE) {
 
+  checkmate::assert_flag(as_cran)
   fail_on <- match.arg(fail_on, c("error", "warning", "note"))
 
   pkgDir <- if (is.null(subdir) || subdir == "~") {
@@ -247,7 +255,8 @@ checkPackage <- function(pkgName,
     bioc_check = bioc_check,
     run_examples = run_examples,
     build_vignettes = build_vignettes,
-    check_vignettes = check_vignettes
+    check_vignettes = check_vignettes,
+    as_cran = as_cran
   )
 
   depsYaml <- file.path(repoDir, "rplatform", "dependencies.yaml")

--- a/man/checkPackage.Rd
+++ b/man/checkPackage.Rd
@@ -14,7 +14,8 @@ checkPackage(
   skip_lint = FALSE,
   skip_tests = FALSE,
   build_vignettes = TRUE,
-  check_vignettes = TRUE
+  check_vignettes = TRUE,
+  as_cran = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,8 @@ values: \code{"note"}, \code{"warning"} (default) and \code{"error"}.}
 \item{build_vignettes}{build vignettes}
 
 \item{check_vignettes}{check vignettes}
+
+\item{as_cran}{run with as_cran flag}
 }
 \value{
 \code{NULL} invisibly.


### PR DESCRIPTION
# Description
add support for running `R CMD CHECK` with `--as-cran`


# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
