### PR TITLE
Gdr 3075

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 1.7.2
-Date: 2025-05-26
+Version: 1.7.3
+Date: 2025-08-03
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRstyle 1.7.3 - 2025-08-04
+* added support for skipping vignette building in `run_tests.sh`
+
 ## gDRstyle 1.7.2 - 2025-05-26
 * add check for `pkgdown` in the `checkPackage` function
 

--- a/R/check.R
+++ b/R/check.R
@@ -156,6 +156,7 @@ rcmd_check_with_notes <- function(pkgDir,
       `no-check-unit-tests` = TRUE, # unit tests are called in previous step
       `no-check-formatting` = TRUE, # follow gDR style guides
       `no-check-CRAN` = TRUE, # may cause random error in CI
+      `no-check-description` = TRUE, # to prevent missing `fnd` NOTE
       `no-check-version-num` = TRUE,
       `no-check-R-ver` = TRUE
     )

--- a/R/check.R
+++ b/R/check.R
@@ -251,7 +251,7 @@ checkPackage <- function(pkgName,
 
   if (!skip_pkgdown) {
     message("Pkgdown")
-    pkgdown::build_site(
+    pkgdown::build_reference(
       pkg = pkgDir,
       override = list(destination = tempfile()),
       preview = FALSE

--- a/inst/scripts/run_tests.R
+++ b/inst/scripts/run_tests.R
@@ -21,12 +21,12 @@ invisible(
 
 # Check package
 gDRstyle::checkPackage(
-  PKG_NAME, 
-  REPO_DIR, 
-  PKG_SUBDIR, 
-  FAIL_ON, 
-  BIOC_CHECK, 
-  RUN_EXAMPLES,
-  CHECK_VIGNETTES,
-  CHECK_VIGNETTES
+  pkgName = PKG_NAME, 
+  repoDir = REPO_DIR, 
+  subdir = PKG_SUBDIR, 
+  fail_on = FAIL_ON, 
+  bioc_check = BIOC_CHECK, 
+  run_examples = RUN_EXAMPLES,
+  build_vignettes = CHECK_VIGNETTES,
+  check_vignettes = CHECK_VIGNETTES
 )

--- a/inst/scripts/run_tests.R
+++ b/inst/scripts/run_tests.R
@@ -7,6 +7,7 @@ LIB_DIR <- args[4]
 FAIL_ON <- args[5]
 BIOC_CHECK <- args[6]
 RUN_EXAMPLES <- as.logical(args[7])
+CHECK_VIGNETTES <- as.logical(args[8])
 
 # Load libraries
 stopifnot(dir.exists(LIB_DIR))
@@ -25,5 +26,7 @@ gDRstyle::checkPackage(
   PKG_SUBDIR, 
   FAIL_ON, 
   BIOC_CHECK, 
-  RUN_EXAMPLES
+  RUN_EXAMPLES,
+  CHECK_VIGNETTES,
+  CHECK_VIGNETTES
 )


### PR DESCRIPTION
# Description
## What changed?
* added support for skipping vignette building in `run_tests.sh`
Related JIRA issue: GDR-3075