### PR TITLE
Gdr 3418

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,13 +94,23 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Trigger GitLab pipeline
+        id: trigger
         run: |
-          curl -s -X POST \
+          RESPONSE=$(curl -s -X POST \
             -F token=${{ secrets.GDRGENESIS_TRIGGER_TOKEN }} \
             -F ref=main \
             -F "variables[PACKAGE_NAME]=${{ github.event.repository.name }}" \
             -F "variables[BRANCH_NAME]=${{ github.head_ref }}" \
-            "https://code.roche.com/api/v4/projects/167859/trigger/pipeline"
+            "https://code.roche.com/api/v4/projects/167859/trigger/pipeline")
+          echo "pipeline_url=$(echo "$RESPONSE" | jq -r '.web_url // empty')" >> "$GITHUB_OUTPUT"
+
+      - name: Post pending test-result status
+        run: |
+          curl -s -X POST \
+            -u "x-access-token:${{ secrets.PRIVATE_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -d "{\"state\":\"pending\",\"context\":\"test-result\",\"description\":\"GitLab pipeline running\",\"target_url\":\"${{ steps.trigger.outputs.pipeline_url }}\"}"
 
   deploy-dev:
     if: github.event.pull_request.merged

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,22 @@ jobs:
         run: gDRstyle::checkPackage("${{ github.event.repository.name }}", ".")
         shell: Rscript {0}
 
+      - name: Post test-result status
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            STATE="success"
+            DESC="External checks passed"
+          else
+            STATE="failure"
+            DESC="External checks failed"
+          fi
+          curl -s -X POST \
+            -u "x-access-token:${{ secrets.PRIVATE_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -d "{\"state\":\"$STATE\",\"context\":\"test-result\",\"description\":\"$DESC\"}"
+
   internal_trigger:
     needs: check_membership
     if: needs.check_membership.outputs.is_team_member == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,11 +41,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == false
     env:
-      TEST_TAG: user/app:latest-${{ github.sha }}
       USERNAME: ${{ github.actor }}
       PACKAGE_NAME: ${{ github.event.repository.name }}
       BRANCH_NAME: ${{ github.head_ref }}
-      BASE_IMAGE: marcinkam/gdrshiny:0.11
     steps:
       - uses: tspascoal/get-user-teams-membership@v1
         id: checkUserMember
@@ -59,25 +57,25 @@ jobs:
       ##########################
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Build
-        uses: docker/build-push-action@v2
+        name: Setup R
+        uses: r-lib/actions/setup-r@v2
         with:
-          context: .
-          load: true
-          tags: ${{ env.TEST_TAG }}
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.PRIVATE_ACCESS_TOKEN }}
-            BASE_IMAGE=${{ env.BASE_IMAGE }}
+          use-public-rspm: true
+
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Run tests
-        run: |
-          docker run -v `pwd`:/mnt/vol ${{ env.TEST_TAG }} bash -c 'bash /mnt/vol/rplatform/run_tests.sh /mnt/vol/'
-      
+        name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::gDRstyle
+
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        name: Run checks
+        run: gDRstyle::checkPackage("${{ env.PACKAGE_NAME }}", ".")
+        shell: Rscript {0}
+
       ##################
       # User from Gene #
       ##################

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@
 # See https://github.com/r-lib/actions/tree/master/examples#readme for
 # additional example workflows available for the R community.
 
-name: main
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,72 +37,66 @@ on:
         required: true
 
 jobs:
-  package_test:
+  check_membership:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == false
-    env:
-      USERNAME: ${{ github.actor }}
-      PACKAGE_NAME: ${{ github.event.repository.name }}
-      BRANCH_NAME: ${{ github.head_ref }}
+    outputs:
+      is_team_member: ${{ steps.check.outputs.isTeamMember }}
     steps:
       - uses: tspascoal/get-user-teams-membership@v1
-        id: checkUserMember
+        id: check
         with:
-          username: ${{ env.USERNAME }}
+          username: ${{ github.actor }}
           team: 'PR reviewers'
           GITHUB_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
 
-      ##########################
-      # External collaborators #
-      ##########################
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Checkout
+  external_check:
+    needs: check_membership
+    if: needs.check_membership.outputs.is_team_member == 'false'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Setup R
+      - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Install dependencies
+      - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::gDRstyle
 
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-        name: Run checks
-        run: gDRstyle::checkPackage("${{ env.PACKAGE_NAME }}", ".")
+      - name: Run checks
+        run: gDRstyle::checkPackage("${{ github.event.repository.name }}", ".")
         shell: Rscript {0}
 
-      ##################
-      # User from Gene #
-      ##################
-      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
-        name: Wait for test results
+  internal_trigger:
+    needs: check_membership
+    if: needs.check_membership.outputs.is_team_member == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger GitLab pipeline
         run: |
           curl -s -X POST \
             -F token=${{ secrets.GDRGENESIS_TRIGGER_TOKEN }} \
             -F ref=main \
-            -F "variables[PACKAGE_NAME]=${{ env.PACKAGE_NAME }}" \
-            -F "variables[BRANCH_NAME]=${{ env.BRANCH_NAME }}" \
+            -F "variables[PACKAGE_NAME]=${{ github.event.repository.name }}" \
+            -F "variables[BRANCH_NAME]=${{ github.head_ref }}" \
             "https://code.roche.com/api/v4/projects/167859/trigger/pipeline"
-          exit 1
+
   deploy-dev:
     if: github.event.pull_request.merged
     runs-on: ubuntu-24.04
-    env:
-      BRANCH_NAME: ${{ github.head_ref }}
-      COMMIT_HASH: ${{ github.sha }}
-      COMMIT_MSG: ${{ github.event.head_commit.message }}
     steps:
-      - run: |
+      - name: Trigger deploy pipeline
+        run: |
           curl -s -X POST \
             -F token=${{ secrets.GDRVIZ_TRIGGER_TOKEN }} \
             -F ref=main \
-            -F "variables[SOURCE_BRANCH]=${{ env.BRANCH_NAME }}" \
-            -F "variables[COMMIT_HASH]=${{ env.COMMIT_HASH }}" \
-            -F "variables[COMMIT_MSG]=${{ env.COMMIT_MSG }}" \
+            -F "variables[SOURCE_BRANCH]=${{ github.head_ref }}" \
+            -F "variables[COMMIT_HASH]=${{ github.sha }}" \
+            -F "variables[COMMIT_MSG]=${{ github.event.head_commit.message }}" \
             -F "variables[TESTS_RESULT]=SUCCESSFUL" \
             "https://code.roche.com/api/v4/projects/181632/trigger/pipeline"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -53,12 +53,12 @@ jobs:
 
       - name: Build pkgdown site
         if: ${{ inputs.IS_SUBDIR != 'true' }}
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)
         shell: Rscript {0}
 
       - name: Build pkgdown site (subdirectory)
         if: ${{ inputs.IS_SUBDIR == 'true' }}
-        run: pkgdown::build_site_github_pages(pkg = "${{ inputs.PACKAGE_NAME }}", new_process = FALSE, install = FALSE)
+        run: pkgdown::build_site_github_pages(pkg = "${{ inputs.PACKAGE_NAME }}", new_process = FALSE, install = TRUE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,5 @@
 # This workflow is used to update static webpage with documentation for the given GitHub repository.
-# It's triggered by the push of the default branch. 
+# It's triggered by the push of the default branch.
 # More details: https://docs.google.com/document/d/1WGW4_lOOZ73lEfVZwIWMivbyCgDTJAajxP5N8767DZY
 
 name: pkgdown
@@ -25,11 +25,6 @@ on:
         required: false
         type: string
         default: 'false'
-    secrets:
-      PRIVATE_ACCESS_TOKEN:
-        required: true
-      GITLAB_ACCESS_TOKEN:
-        required: true
 
 permissions:
   contents: write
@@ -37,47 +32,37 @@ permissions:
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      TEST_TAG: user/app:latest-${{ github.sha }}
-      USERNAME: ${{ github.actor }}
-      PACKAGE_NAME: ${{ github.event.repository.name }}
-      BRANCH_NAME: ${{ github.head_ref }}
-      BASE_IMAGE: marcinkam/gdrshiny:1.0
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build
-        uses: docker/build-push-action@v5
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
         with:
-          context: .
-          fetch-depth: 0
-          ref: ${{ env.BRANCH_NAME }}
-          tags: ${{ env.TEST_TAG }}
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.PRIVATE_ACCESS_TOKEN }}
-            GITLAB_PAT=${{ secrets.GITLAB_ACCESS_TOKEN }}
-            BASE_IMAGE=${{ env.BASE_IMAGE }}
+          use-public-rspm: true
 
-      - name: Run pkgdown
-        if: ${{ inputs.IS_SUBDIR  != 'true' }}
-        run: |
-          docker run -v `pwd`:/mnt/vol ${{ env.TEST_TAG }} Rscript -e 'pkgdown::build_site_github_pages("/mnt/vol", new_process = FALSE, install = FALSE)'
-      
-      # currently, internal packages are stored as subdirectories in the repository
-      # eventually, this loop becomes obsolete (subdirectory structure is not allowed in Bioconductor))
-      - name: Run pkgdown (R package as subdirectory)
-        if: ${{ inputs.IS_SUBDIR  == 'true' }}
-        run: |
-          docker run -v $GITHUB_WORKSPACE:/mnt/vol ${{ env.TEST_TAG }} bash  -c "find /mnt/vol/${{ env.PACKAGE_NAME }}"
-          docker run -v `pwd`:/mnt/vol ${{ env.TEST_TAG }} Rscript -e 'pkgdown::build_site_github_pages("/mnt/vol/${{ env.PACKAGE_NAME }}", new_process = FALSE, install = FALSE)'
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown
+          needs: website
 
-      - name: Deploy to GitHub pages 🚀
-        if: ${{ inputs.IS_SUBDIR  != 'true' }}
+      - name: Build pkgdown site
+        if: ${{ inputs.IS_SUBDIR != 'true' }}
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Build pkgdown site (subdirectory)
+        if: ${{ inputs.IS_SUBDIR == 'true' }}
+        run: pkgdown::build_site_github_pages(pkg = "${{ inputs.PACKAGE_NAME }}", new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages
+        if: ${{ inputs.IS_SUBDIR != 'true' }}
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: true
@@ -85,11 +70,11 @@ jobs:
           folder: docs
           target-folder: docs
 
-      - name: Deploy to GitHub pages 🚀 (R package as subdirectory)
-        if: ${{ inputs.IS_SUBDIR  == 'true' }}
+      - name: Deploy to GitHub pages (subdirectory)
+        if: ${{ inputs.IS_SUBDIR == 'true' }}
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: true
           branch: pages
-          folder: ${{ env.PACKAGE_NAME }}/docs
+          folder: ${{ inputs.PACKAGE_NAME }}/docs
           target-folder: docs


### PR DESCRIPTION
# Description
## What changed?
Replaced the Docker-based pkgdown workflow with a lightweight r-lib/actions-based approach. Removed dependency on the marcinkam/gdrshiny Docker image, docker/build-push-action, and private access token secrets. The workflow now uses  r-lib/actions/setup-r and r-lib/actions/setup-r-dependencies to install R and package dependencies directly on the runner.

Related JIRA issue: GDR-3418

## Why was it changed?
The Docker base image marcinkam/gdrshiny:1.0 is no longer accessible on Docker Hub, causing all pkgdown workflow runs to fail. Since all github gDR packages are publicly available in Bioconductor and on GitHub, Docker is unnecessary for pkgdown site generation. The r-lib/actions approach is the standard in the R community — simpler, easier to maintain, and has no external image dependency

EDIT: 
- Replaced Docker-based CI workflow (main.yml) with r-lib/actions, calling gDRstyle::checkPackage() directly instead of per-repo rplatform/run_tests.sh
- Split CI into separate jobs: check_membership, external_check, internal_trigger, deploy-dev
- Removed exit 1 hack — internal_trigger now succeeds after triggering GitLab
- external_check posts test-result commit status, matching GitLab's behavior for consistent branch protection
- Renamed workflow display name from main to CI
- Branch protection should require test-result status check (from any source)