### PR TITLE
fix: allow License NOTE for packages with file LICENSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gDRstyle
 Type: Package
 Title: A package with style requirements for the gDR suite 
-Version: 1.11.4
-Date: 2026-05-27
+Version: 1.11.5
+Date: 2026-06-17
 Authors@R: c(
     person("Allison", "Vuong", role=c("aut")),
     person("Dariusz", "Scigocki", role=c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRstyle 1.11.5 - 2026-06-17
+* allow License NOTE for packages with file LICENSE
+
 ## gDRstyle 1.11.4 - 2026-05-27
 * apply updated gDRstyle rules
 

--- a/inst/config/note.json
+++ b/inst/config/note.json
@@ -47,8 +47,8 @@
     },
     {
       "length": 3,
-      "index_to_check": 2,
-      "text_to_check": "License components with restrictions not permitted"
+      "index_to_check": 3,
+      "text_to_check": "Artistic-2.0"
     }
   ]
 }

--- a/inst/config/note.json
+++ b/inst/config/note.json
@@ -44,6 +44,11 @@
       "length": [3, 4, 5, 6],
       "index_to_check": 2,
       "text_to_check": "installed size"
+    },
+    {
+      "length": 3,
+      "index_to_check": 2,
+      "text_to_check": "License components with restrictions not permitted"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add License NOTE to global valid_notes config to allow `Artistic-2.0 + file LICENSE` in DESCRIPTION

## Test plan
- [ ] Verify gDRplots CI passes with this change